### PR TITLE
fix:解决引入0.72.48框架版本后地图view创建不成功的问题

### DIFF
--- a/harmony/baidu_map/src/main/ets/BaiduMapView.ets
+++ b/harmony/baidu_map/src/main/ets/BaiduMapView.ets
@@ -131,6 +131,7 @@ export struct BaiduMapView {
   polygonProp: BaiduMapOverlayPolygonProps | null = null;
   markerProp: BaiduMapOverlayMarkerProps | null = null;
   image: ImageEntity | null = null;
+  @State isInit: boolean = false;
 
   onMapStatusChangeStart(): void {
     this.ctx.rnInstance.emitComponentEvent(
@@ -228,7 +229,9 @@ export struct BaiduMapView {
         this.getProp(this.descriptor);
       }
     )
-
+    setTimeout(() => {
+      this.isInit = true;
+    }, 5)
   }
 
   private getProp(descriptor: BaiduMapViewDescriptor) {
@@ -489,6 +492,7 @@ export struct BaiduMapView {
 
   build() {
     RNViewBase({ ctx: this.ctx, tag: this.tag }) {
+      if (this.isInit) {
       MapComponent({
         onReady: async (err: BusinessError, mapController: MapController) => {
           if (!err && mapController) {
@@ -526,6 +530,7 @@ export struct BaiduMapView {
           }
         }, mapOptions: this.mapOpt
       }).width('100%').height('100%')
+      }
     }
   }
 }


### PR DESCRIPTION
# Summary

-解决引入0.72.48框架版本后地图view创建不成功的问题

## Test Plan

异常图：
![image](https://github.com/user-attachments/assets/39c3ccb6-d2a0-493a-8f8b-954167fb56fe)
正常图：
![image](https://github.com/user-attachments/assets/04d7a184-ed16-4da5-938b-4b926da03e67)


## Checklist

<!-- 检查项, 请自行排查并打钩, 通过: [X] -->

- [X] 已经在真机设备或模拟器上测试通过
- [ ] 已经与 Android 或 iOS 平台做过效果/功能对比
- [ ] 已经添加了对应 API 的测试用例（如需要）
- [ ] 已经更新了文档（如需要）
- [ ] 更新了 JS/TS 代码 (如有)